### PR TITLE
Default to the current GitHub user

### DIFF
--- a/gh-cat
+++ b/gh-cat
@@ -72,6 +72,11 @@ if [[ ! $repo || ${#paths[@]} == 0 ]]; then
   usage
 fi
 
+if [[ ! $repo =~ .*/.* ]]; then
+  user="$(gh config get -h github.com user)"
+  repo="$user/$repo"
+fi
+
 if [[ ! $branch ]]; then
   branch=$(gh api "repos/$repo" --jq '.default_branch')
 fi


### PR DESCRIPTION
This allows you to specify just the repository name if it belongs to the current github.com user (as determined by `gh`).