### PR TITLE
Print using a cat-style command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Arguments:
 
 Options:
     -b, --branch    branch or tag name
+    -c, --cmd       cat-style output command
     -h, --help      print usage
     -v, --version   print version
     -V, --verbose   enable debug output
@@ -22,11 +23,20 @@ Dependencies: curl
 Examples:
     gh cat jparise/gh-cat README.md
     gh cat jparise/gh-cat README.md LICENSE > file
+    gh cat jparise/gh-cat -c "bat --number" README.md
     gh cat cli/cli -b trunk README.md
 ```
 
 It can be run as a standalone executable (`gh-cat`) or as a
 [GitHub CLI extension](https://cli.github.com/manual/gh_extension).
+
+Files will be piped to a cat-style command for printing. The first available of
+`batcat`, `bat`, or `cat` will be used by default, but this command can also be
+explicitly specified using the `--cmd` option.
+
+When [bat][] is used, its `--file-name` argument will be added automatically.
+
+[bat]: https://github.com/sharkdp/bat
 
 ## Installation
 
@@ -48,6 +58,9 @@ $ gh cat jparise/gh-cat README.md
 # Print the concatenated contents of README.md and LICENSE and redirect that
 # output to `file`
 $ gh cat jparise/gh-cat README.md LICENSE > file
+
+# Print the contents of README.md using the command `bat --number`.
+$ gh cat jparise/gh-cat -c "bat --number" README.md
 
 # Print the contents of README.md from the cli/cli repository's `trunk` branch
 $ gh cat cli/cli -b trunk README.md

--- a/gh-cat
+++ b/gh-cat
@@ -18,6 +18,7 @@ Arguments:
 
 Options:
     -b, --branch    branch or tag name
+    -c, --cmd       cat-style output command
     -h, --help      print usage
     -v, --version   print version
     -V, --verbose   enable debug output
@@ -27,6 +28,7 @@ Dependencies: curl
 Examples:
     gh cat jparise/gh-cat README.md
     gh cat jparise/gh-cat README.md LICENSE > file
+    gh cat jparise/gh-cat -c "bat --number" README.md
     gh cat cli/cli -b trunk README.md
 EOF
   exit
@@ -35,6 +37,12 @@ EOF
 repo=""
 branch=""
 paths=()
+
+for cmd in batcat bat cat; do
+  if type -p "$cmd" >/dev/null; then
+    break
+  fi
+done
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -52,6 +60,10 @@ while [[ $# -gt 0 ]]; do
       branch="$2"
       shift 2
       ;;
+    -c | --cmd)
+      cmd="$2"
+      shift 2
+      ;;
     *)
       if [[ ! $repo ]]; then
         repo="$1"
@@ -67,12 +79,13 @@ if [[ ! $repo || ${#paths[@]} == 0 ]]; then
   usage
 fi
 
-for cmd in curl gh; do
-  if ! type -p "$cmd" >/dev/null; then
-    echo "error: $cmd not found on the system" >&2
+for bin in curl gh; do
+  if ! type -p "$bin" >/dev/null; then
+    echo "error: $bin not found on the system" >&2
     exit 1
   fi
 done
+unset "$bin"
 
 if [[ ! $repo =~ .*/.* ]]; then
   user="$(gh config get -h github.com user)"
@@ -86,8 +99,16 @@ fi
 token=$(gh auth token)
 readonly token
 
+_cat() {
+  if [[ $cmd == bat* ]]; then
+    $cmd --file-name "$1"
+  else
+    $cmd
+  fi
+}
+
 for path in "${paths[@]}"; do
   curl -fsL --oauth2-bearer "$token" \
-    "https://raw.githubusercontent.com/$repo/$branch/$path" ||
+    "https://raw.githubusercontent.com/$repo/$branch/$path" | _cat "$path" ||
     (echo "$repo: $path: not found or unavailable" >&2; exit 1)
 done


### PR DESCRIPTION
With this change, the files are now piped through an output command for printing. By default, we'll use the first available of `batcat`, `bat`, or `cat`, but this command can also be explicitly specified using the `--cmd` option.

When bat is used, its `--file-name` argument will be added automatically.